### PR TITLE
slip into cheaper pricing band

### DIFF
--- a/server/data/README.md
+++ b/server/data/README.md
@@ -12,7 +12,7 @@ Datasets include the static large datasets such as Iwahashi and Pike, Geology QM
 ```
 
 ## Step 2: Create mbtiles with tippecanoe
-This allows more flexibility by being able to specify zoom levels where data is available amongst other things.
+This allows more flexibility by being able to specify zoom levels where data is available amongst other things. Note the current pricing of tileset uploads and hosting. Currently zoom level 13 (~1m) is much cheaper than 14 (0.5m) or greater.
 ```
 ./prepare2.sh
 ```

--- a/server/data/prepare2.sh
+++ b/server/data/prepare2.sh
@@ -4,9 +4,9 @@
 #
 TIPPECANOE="/opt/tippecanoe/bin/tippecanoe"
 
-$TIPPECANOE -l vspr -n "Measured Vs30 Sites" -Z0 -z14 -rg -o vspr.mbtiles vspr.geojson --force
-$TIPPECANOE -l aak_map -n "AhdiAK Geology Category Map" -Z0 -z14 -rg -o aak_map.mbtiles aak_map.geojson --force
-$TIPPECANOE -l ip_map -n "Iwahashi and Pike Terrain Category Map" -Z0 -z14 -rg -o ip_map.mbtiles iwahashipike.geojson --force --coalesce-fraction-as-needed
-$TIPPECANOE -l aak_vs30 -n "AhdiAK Vs30 Map" -Z0 -z14 -rg -o aak.mbtiles aak.geojson --force --coalesce-fraction-as-needed
-$TIPPECANOE -l yca_vs30 -n "YongCA Vs30 Map" -Z0 -z14 -rg -o yca.mbtiles yca.geojson --force --coalesce-fraction-as-needed
-$TIPPECANOE -l combined_vs30 -n "Combined Vs30 Map" -Z0 -z14 -rg -o combined.mbtiles combined.geojson --force --coalesce-fraction-as-needed
+$TIPPECANOE -l vspr -n "Measured Vs30 Sites" -Z0 -z13 -rg -o vspr.mbtiles vspr.geojson --force
+$TIPPECANOE -l aak_map -n "AhdiAK Geology Category Map" -Z0 -z13 -rg -o aak_map.mbtiles aak_map.geojson --force
+$TIPPECANOE -l ip_map -n "Iwahashi and Pike Terrain Category Map" -Z0 -z13 -rg -o ip_map.mbtiles iwahashipike.geojson --force --coalesce-fraction-as-needed
+$TIPPECANOE -l aak_vs30 -n "AhdiAK Vs30 Map" -Z0 -z13 -rg -o aak.mbtiles aak.geojson --force --coalesce-fraction-as-needed
+$TIPPECANOE -l yca_vs30 -n "YongCA Vs30 Map" -Z0 -z13 -rg -o yca.mbtiles yca.geojson --force --coalesce-fraction-as-needed
+$TIPPECANOE -l combined_vs30 -n "Combined Vs30 Map" -Z0 -z13 -rg -o combined.mbtiles combined.geojson --force --coalesce-fraction-as-needed


### PR DESCRIPTION
Making tiles at ~1m resolution from 0.5m.

This changes price for uploads, hosting/month for 6/6 tilesets:
$335, $17
To:
$15, $0.70

Above is without design changes, could change so that squares share same tilesets, pricing would be:
$3, $0.20
but would require a bit more effort (~2 days to smooth it out)

Further details:
https://www.mapbox.com/pricing/#processing10m