### PR TITLE
Use layered

### DIFF
--- a/VsViewer/frontend/src/components/VsProfile.js
+++ b/VsViewer/frontend/src/components/VsProfile.js
@@ -41,7 +41,7 @@ const VsProfile = () => {
   // Form variables
   const [file, setFile] = useState("");
   const [vsProfileName, setVsProfileName] = useState("");
-  const [layered, setLayered] = useState(false);
+  const [layered, setLayered] = useState(true);
   const [VsProfileOptions, setVsProfileOptions] = useState([]);
   const [loading, setLoading] = useState(false);
   const [canSet, setCanSet] = useState(false);
@@ -328,6 +328,7 @@ const VsProfile = () => {
               <input
                 className="col-1 vs-checkbox"
                 type="checkbox"
+                checked={layered}
                 onChange={(e) => setLayered(e.target.checked)}
               />
             </div>

--- a/VsViewer/vs_calc/VsProfile.py
+++ b/VsViewer/vs_calc/VsProfile.py
@@ -257,7 +257,7 @@ class VsProfile:
         """
         Calculates the average Vs at the max Z depth for the given VsProfile
         """
-        vs_midpoint, depth_midpoint = utils.convert_to_midpoint(self.vs, self.depth)
+        vs_midpoint, depth_midpoint = utils.convert_to_midpoint(self.vs, self.depth, self.layered)
         time = 0
         for ix in range(1, len(vs_midpoint), 2):
             change_in_z = depth_midpoint[ix] - depth_midpoint[ix - 1]


### PR DESCRIPTION
Ensures that we utilize the layered feature of convert_to_midpoint function.
For VsProfiles the Vs value is usually at the point of depth (not requiring a half point calculation between depths)
Changed default for layered to be true in the web app too