### PR TITLE
Prevent the possibility of an infinite while loop in calc_cpt_params

### DIFF
--- a/VsViewer/vs_calc/CPT.py
+++ b/VsViewer/vs_calc/CPT.py
@@ -5,6 +5,8 @@ from typing import Dict
 import numpy as np
 import pandas as pd
 
+class ExceededMaxIterations(Exception):
+    pass
 
 class CPT:
     """
@@ -155,7 +157,7 @@ class CPT:
         gamma = np.maximum(14.0 / 1000, gamma)
         return gamma
 
-    def calc_cpt_params(self):
+    def calc_cpt_params(self, max_iterations: int = 1e6):
         """
         Compute and save Qtn, Ic, n, effStress and totalStress CPT parameters
 
@@ -171,6 +173,9 @@ class CPT:
             Cone resistance factor exponent
         totalStress : np.ndarray
             Total stress
+        max_iterations : int
+            Maximum number of allowed iterations
+
 
         References
         ----------
@@ -205,8 +210,9 @@ class CPT:
             iteration_counter = 0
             while deltan >= 0.01:
                 iteration_counter += 1
-                if iteration_counter > 1e6:
-                    raise ValueError("CPT params calculation could not converge")
+                if iteration_counter > max_iterations:
+                    raise ExceededMaxIterations(f"Exceeded the maximum number of iterations of {max_iterations:.1e}"
+                                                f"for {self.name}")
                 n0 = n[i]
                 cN = (pa / effStress[i]) ** n[i]
                 if cN > 1.7:

--- a/VsViewer/vs_calc/CPT.py
+++ b/VsViewer/vs_calc/CPT.py
@@ -202,7 +202,11 @@ class CPT:
         for i in range(0, len(n)):
             deltan = 1
             # iterate Qtn, Ic and n until convergence
+            iteration_counter = 0
             while deltan >= 0.01:
+                iteration_counter += 1
+                if iteration_counter > 1e6:
+                    raise ValueError("CPT params calculation could not converge")
                 n0 = n[i]
                 cN = (pa / effStress[i]) ** n[i]
                 if cN > 1.7:

--- a/VsViewer/vs_calc/CPT.py
+++ b/VsViewer/vs_calc/CPT.py
@@ -211,8 +211,8 @@ class CPT:
             while deltan >= 0.01:
                 iteration_counter += 1
                 if iteration_counter > max_iterations:
-                    raise ExceededMaxIterations(f"Exceeded the maximum number of iterations of {max_iterations:.1e}"
-                                                f"for {self.name}")
+                    raise ExceededMaxIterations(f"Exceeded the maximum number of iterations ({max_iterations:.1e}) "
+                                                f"for {self.name} without converging to a numerical solution.")
                 n0 = n[i]
                 cN = (pa / effStress[i]) ** n[i]
                 if cN > 1.7:


### PR DESCRIPTION
calc_cpt_params was unable to converge to a solution for some of the new CPT data, resulting in an infinite while loop.
As a quick fix, it now raises a ValueError if reaches 1e6 iterations, which takes about 2 or 3 seconds. I don't know how many iterations are usually required so I just set the limit to be very high.